### PR TITLE
Set critical_validators to null if there are no critical peers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="stellar-core-prometheus-exporter",
-    version="0.9.5",
+    version="0.9.6",
     author="Stellar Development Foundation",
     author_email="ops@stellar.org",
     description="Export stellar core metrics in prometheus format",

--- a/stellar_core_prometheus_exporter/exporter.py
+++ b/stellar_core_prometheus_exporter/exporter.py
@@ -302,7 +302,7 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                         l = self.labels + [critical_peers]
                         g.labels(*l).set(1)
                 else:
-                    l = self.labels + ['']  # critical_validators label set to empty string
+                    l = self.labels + ['null']
                     g.labels(*l).set(0)
 
         # Peers metrics


### PR DESCRIPTION
The label needs to be set to non-empty string otherwise
it's not exported at all.