### PR TITLE
Handle missing keys in info endpoint for command line catchup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="stellar-core-prometheus-exporter",
-    version="0.10.2",
+    version="0.10.3",
     author="Stellar Development Foundation",
     author_email="ops@stellar.org",
     description="Export stellar core metrics in prometheus format",

--- a/stellar_core_prometheus_exporter/exporter.py
+++ b/stellar_core_prometheus_exporter/exporter.py
@@ -277,17 +277,22 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
                                     tmp[metric]
                                     )
             except KeyError as e:
-                self.log_message('Unable to find metric in quorum qset: {}. This is probably fine and will fix itself as stellar-core joins the quorum.'.format(metric))
+                self.log_message('Unable to find metric in quorum qset: {}. This is probably fine and will fix itself as stellar-core joins the quorum, or core is running cli catchup'.format(metric))
 
-        for metric in self.quorum_phase_metrics:
-            if tmp['phase'].lower() == metric:
-                value = 1
-            else:
-                value = 0
-            self.registry.Gauge('stellar_core_quorum_phase_{}'.format(metric),
-                                'Stellar core quorum phase {}'.format(metric),
-                                value=value,
-                                )
+        try:
+
+            for metric in self.quorum_phase_metrics:
+                if tmp['phase'].lower() == metric:
+                    value = 1
+                else:
+                    value = 0
+                self.registry.Gauge('stellar_core_quorum_phase_{}'.format(metric),
+                                    'Stellar core quorum phase {}'.format(metric),
+                                    value=value,
+                                    )
+        except KeyError as e:
+                self.log_message('Unable to find phase in quorum qset. This is probably fine and will fix itself as stellar-core joins the quorum, or core is running cli catchup')
+
         # Versions >=11.2.0 expose more info about quorum
         if 'transitive' in info['quorum']:
             if info['quorum']['transitive']['intersection']:


### PR DESCRIPTION
We're adding metrics scraping for command line catchup in Supercluster, and these changes are required to keep the exporter from crashing.