### PR TITLE
Catch KeyboardInterrupt and exit gracefully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="stellar-core-prometheus-exporter",
-    version="0.10.3",
+    version="0.10.4",
     author="Stellar Development Foundation",
     author_email="ops@stellar.org",
     description="Export stellar core metrics in prometheus format",

--- a/stellar_core_prometheus_exporter/exporter.py
+++ b/stellar_core_prometheus_exporter/exporter.py
@@ -411,4 +411,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted')


### PR DESCRIPTION
The prometheus container ends up with an error code on shutdown in Supercluster, and (I think) it's due to this based on the logs. SSC job pods get killed with a `killall5`, which also kills the Prometheus container. This is fine, but it looks like the container reports an error due to this.
```
Traceback (most recent call last):
  File "/usr/bin/stellar-core-prometheus-exporter", line 11, in <module>
    load_entry_point('stellar-core-prometheus-exporter==0.10.3', 'console_scripts', 'stellar-core-prometheus-exporter')()
  File "/usr/lib/python3/dist-packages/stellar_core_prometheus_exporter/__init__.py", line 3, in run
    exporter.main()
  File "/usr/lib/python3/dist-packages/stellar_core_prometheus_exporter/exporter.py", line 410, in main
    time.sleep(1)
KeyboardInterrupt
```