### PR TITLE
Update Ubuntu to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - && \
-    echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list
+    echo "deb https://apt.stellar.org jammy stable" | tee -a /etc/apt/sources.list.d/SDF.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends stellar-core-prometheus-exporter
 
 EXPOSE 9473


### PR DESCRIPTION
### What:


Update Ubuntu to 22.04 from 20.04

### Why:

We are migrating Ubuntu base images to 22.04. 

### Testing:
I built the image and it was successful 