### PR TITLE
Add the `--host` configuration item.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Optional config can be provided using CLI arguments or environment variables.
 
 Supported configuration options:
 * **--stellar-core-address** - address of monitored stellar-core. Defaults to `http://127.0.0.1:11626`. Can also be set using `STELLAR_CORE_ADDRESS` environment variable
+* **--host** - listening address. Defaults to `0.0.0.0`. Can also be set using `HOST` environment variable
 * **--port** - listening port. Defaults to `9473`. Can also be set using `PORT` environment variable
 
 # Grafana dashboard

--- a/stellar_core_prometheus_exporter/exporter.py
+++ b/stellar_core_prometheus_exporter/exporter.py
@@ -26,6 +26,10 @@ parser.add_argument('--stellar-core-address', type=str,
                     help='Stellar core address. Defaults to STELLAR_CORE_ADDRESS environment '
                          'variable or if not set to http://127.0.0.1:11626',
                     default=environ.get('STELLAR_CORE_ADDRESS', 'http://127.0.0.1:11626'))
+parser.add_argument('--host', type=str,
+                    help='HTTP bind address. Defaults to HOST environment variable '
+                         'or if not set to 0.0.0.0',
+                    default=environ.get('HOST', '0.0.0.0'))
 parser.add_argument('--port', type=int,
                     help='HTTP bind port. Defaults to PORT environment variable '
                          'or if not set to 9473',
@@ -402,7 +406,7 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
 
 
 def main():
-    httpd = _ThreadingSimpleServer(("", args.port), StellarCoreHandler)
+    httpd = _ThreadingSimpleServer((args.host, args.port), StellarCoreHandler)
     t = threading.Thread(target=httpd.serve_forever)
     t.daemon = True
     t.start()


### PR DESCRIPTION
In the current version of stellar-core-prometheus-exporter, the server is bound to `0.0.0.0` by default, which means it listens on all network interfaces. While this is generally acceptable, some users may require more granular network configuration options. For instance, for security reasons, some users may prefer to bind only to a specific local address or loopback address.