### PR TITLE
upgrade to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gnupg2 wget apt-utils apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add - && \


### PR DESCRIPTION
### What
upgrade to 24.04

### Why
24.04

### Testing before merge
- successful build against this branch: https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-core-prometheus-exporter-public-docker/8/
- push to docker.io
- verify wallet-eng freighter-ingest container `wget http://localhost:9473/metrics`

### Validation after merge
the pods pull `latest` so nothing to do 

### Issue addressed by this PR
https://github.com/stellar/ops/issues/4358